### PR TITLE
Allow tests on cljc files

### DIFF
--- a/src/adzerk/boot_test.clj
+++ b/src/adzerk/boot_test.clj
@@ -5,7 +5,7 @@
             [boot.core :as core]))
 
 (def pod-deps
-  '[[org.clojure/tools.namespace "0.2.10" :exclusions [org.clojure/clojure]]
+  '[[org.clojure/tools.namespace "0.2.11" :exclusions [org.clojure/clojure]]
     [pjstadig/humane-test-output "0.6.0"  :exclusions [org.clojure/clojure]]])
 
 (defn init [fresh-pod]


### PR DESCRIPTION
I know in the future boot will probably want to use `core/fileset-namespaces` but for now if you can do a release with this simple change it will allow us to run tests where cljc files are involved.