### PR TITLE
Add a test summary even when no namespaces were tested

### DIFF
--- a/src/adzerk/boot_test.clj
+++ b/src/adzerk/boot_test.clj
@@ -110,9 +110,10 @@
                 (vary-meta assoc :clojure.test/result summary)
                 (core/add-asset tmp)
                 core/commit!))
-          (do
+          (let [summary {:test 0, :pass 0, :fail 0, :error 0}] ; from clojure.test/*initial-report-counters*
             (println "No namespaces were tested.")
-            fileset))))))
+            (-> fileset
+                (vary-meta assoc :clojure.test/result summary))))))))
 
 (core/deftask test
   "Run clojure.test tests in a pod. Throws on test errors or failures.


### PR DESCRIPTION
This is good for consistency, but also because the test task was failing when it looks for the test summary to see if some tests failed to throw an exception.

To reproduce the issue, run the following:

```
> boot test -e adzerk.boot-test -e adzerk.boot-test.test
```

the output will be something like:
 
```
No namespaces were tested.
Writing target dir(s)...
             clojure.lang.ExceptionInfo: java.lang.NullPointerException
    data: {:file "/tmp/boot.user7806717788834611270.clj", :line 17}
java.util.concurrent.ExecutionException: java.lang.NullPointerException
         java.lang.NullPointerException: 
                clojure.core/map/fn       core.clj: 2622
                                ...                     
                   clojure.core/seq       core.clj:  137
                 clojure.core/apply       core.clj:  630
  adzerk.boot-test/eval353/fn/fn/fn  boot_test.clj:  150
     boot.task.built-in/fn/fn/fn/fn   built_in.clj:  221
  adzerk.boot-test/eval304/fn/fn/fn  boot_test.clj:   89
                boot.core/run-tasks       core.clj:  794
                  boot.core/boot/fn       core.clj:  804
clojure.core/binding-conveyor-fn/fn       core.clj: 1916
                                ...
```

After this fix, the exception is gone.