### PR TITLE
Fix junit-output-to OPTARG. Should not use -

### DIFF
--- a/src/adzerk/boot_test.clj
+++ b/src/adzerk/boot_test.clj
@@ -135,7 +135,7 @@
    e exclusions NAMESPACE #{sym} "The set of namespace symbols to be excluded from test."
    f filters    EXPR      #{edn} "The set of expressions to use to filter namespaces."
    r requires   REQUIRES  #{sym} "Extra namespaces to pre-load into the pool of test pods for speed."
-   j junit-output-to JUNIT-OUT str "The directory where a junit formatted report will be generated for each ns"]
+   j junit-output-to JUNITOUT str "The directory where a junit formatted report will be generated for each ns"]
   (comp
     (run-tests :namespaces namespaces
                :exclusions exclusions


### PR DESCRIPTION
Instead of JUNIT-OUT the optarg must be JUNITOUT, to avoid splitting

From boot wiki:

> any non alpha-numeric character in the optarg placeholder is interpreted as a character to split on

This was making it impossible to pass the junit-output-to option from the command line

Fixes #24