### PR TITLE
insert a flush at the end of do-report

### DIFF
--- a/src/adzerk/boot_test.clj
+++ b/src/adzerk/boot_test.clj
@@ -20,6 +20,9 @@
               '[clojure.tools.namespace.find :refer [find-namespaces-in-dir]])
      (activate!)
 
+     ;; flush report output as it happens
+      (alter-var-root #'t/do-report (fn [fun] (fn [& args] (let [result (apply fun args)] (flush) result))))                                                                                                                                         
+
      (defn all-ns* [& dirs]
        (distinct (mapcat #(find-namespaces-in-dir (io/file %)) dirs)))
 


### PR DESCRIPTION
for whatever reason report output doesn't completely print until something else forces a flush, so you never get a complete report if, for example, something in the test hangs