### PR TITLE
Adds omit-stacktrace? to ex data

### DIFF
--- a/src/adzerk/boot_test.clj
+++ b/src/adzerk/boot_test.clj
@@ -181,5 +181,6 @@
       fileset
       (let [summary (:clojure.test/result (meta fileset))]
         (if (> (apply + (map summary [:fail :error])) 0)
-          (throw (ex-info "Some tests failed or errored" summary))
+          (throw (ex-info "Some tests failed or errored"
+                          (assoc summary :boot.util/omit-stacktrace? true)))
           fileset)))))


### PR DESCRIPTION
This way boot does not print the stacktrace after the test summary. I'd say that it fixes #6

The output would look like this now:

```
Testing adzerk.boot-test.test

FAIL in (a-test-that-fails) (test.clj:8)
expected: 0
  actual: 1
    diff: - 0
          + 1

Ran 2 tests containing 2 assertions.
1 failures, 0 errors.
Writing target dir(s)...
Some tests failed or erroredElapsed time: 3.569 sec
```

As opposed to how it looks before this change:

```
Testing adzerk.boot-test.test

FAIL in (a-test-that-fails) (test.clj:8)
expected: 0
  actual: 1
    diff: - 0
          + 1

Ran 2 tests containing 2 assertions.
1 failures, 0 errors.
Writing target dir(s)...
                              java.lang.Thread.run              Thread.java:  745
java.util.concurrent.ThreadPoolExecutor$Worker.run  ThreadPoolExecutor.java:  617
 java.util.concurrent.ThreadPoolExecutor.runWorker  ThreadPoolExecutor.java: 1142
               java.util.concurrent.FutureTask.run          FutureTask.java:  266
                                               ...
               clojure.core/binding-conveyor-fn/fn                 core.clj: 1938
                                 boot.core/boot/fn                 core.clj: 1029
                               boot.core/run-tasks                 core.clj: 1019
                    boot.task.built-in/fn/fn/fn/fn             built_in.clj:  477
                    boot.task.built-in/fn/fn/fn/fn             built_in.clj:  479
                    boot.task.built-in/fn/fn/fn/fn             built_in.clj:  427
                 boot.task.built-in/fn/fn/fn/fn/fn             built_in.clj:  430
              boot.task.built-in/fn/fn/fn/fn/fn/fn             built_in.clj:  430
                 adzerk.boot-test/eval291/fn/fn/fn            boot_test.clj:  105
                    boot.task.built-in/fn/fn/fn/fn             built_in.clj:  382
                 adzerk.boot-test/eval354/fn/fn/fn            boot_test.clj:  184
                              clojure.core/ex-info                 core.clj: 4617
clojure.lang.ExceptionInfo: Some tests failed or errored
    error: 0
     fail: 1
     pass: 1
     test: 2
     type: :summary
Elapsed time: 4.593 sec
```